### PR TITLE
fix zip structure for layer

### DIFF
--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /tmp
 
 RUN yum update -y && yum install -y zip unzip wget tar gzip
 
-RUN pip install -t /assets/python aws-lambda-powertools$PACKAGE_SUFFIX
+RUN pip install -t /asset/python aws-lambda-powertools$PACKAGE_SUFFIX

--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -16,8 +16,4 @@ WORKDIR /tmp
 
 RUN yum update -y && yum install -y zip unzip wget tar gzip
 
-RUN pip install -t /python aws-lambda-powertools$PACKAGE_SUFFIX
-
-
-RUN mkdir -p /asset
-RUN zip -qr /asset/layer.zip /python --exclude \*/tests/\* \*/doc/\* \*/__pycache__/\* \*.pyc
+RUN pip install -t /assets/python aws-lambda-powertools$PACKAGE_SUFFIX


### PR DESCRIPTION
*Issue #35 , if available:*
Closes #35 

*Description of changes:*
Instead of zipping the code we only need to install it into `/asset/python` path, then CDK will package the `python` folder as a zip file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
